### PR TITLE
Decimal encode extension-set example

### DIFF
--- a/draft-ietf-privacypass-auth-scheme-extensions.md
+++ b/draft-ietf-privacypass-auth-scheme-extensions.md
@@ -172,7 +172,7 @@ provided by the origin, or craft its own.
 
 ~~~
 WWW-Authenticate:
-  PrivateToken challenge="abc...", token-key="123...", extension-set="0x0001,0x0002..." extensions="def..."
+  PrivateToken challenge="abc...", token-key="123...", extension-set="1,2..." extensions="def..."
 ~~~
 
 # Extensions Negotiation {#negotiation}


### PR DESCRIPTION
This is intended to address #13. However, I am not sure if this is the right solution. By spec, I think we need to base64 encode the ExtensionSet structure.

We may want to add test/interop vectors to the bottom of the spec in a new section, and substitute these as the example.